### PR TITLE
Allow editor to open files selected from file browser

### DIFF
--- a/src/components/OpenFilePlgSettingTab.ts
+++ b/src/components/OpenFilePlgSettingTab.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import OpenFilePlg from "../main";
 
 export class OpenFilePlgSettingTab extends PluginSettingTab {
@@ -12,9 +12,12 @@ export class OpenFilePlgSettingTab extends PluginSettingTab {
 
 		containerEl.empty();
 
+		const checkSettingConfigTap = createTap<Setting>();
+
 		new Setting(containerEl)
 			.setName("vscode")
 			.setDesc("macOS only")
+			// .then(checkSettingConfigTap.bind(this))
 			.addText((text) =>
 				text
 					.setPlaceholder("Absolute path")
@@ -25,4 +28,11 @@ export class OpenFilePlgSettingTab extends PluginSettingTab {
 					})
 			);
 	}
+}
+
+function createTap<T>() {
+	return function (component: T) {
+		new Notice(JSON.stringify(this.plugin.settingConfig));
+		return this;
+	};
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -239,10 +239,17 @@ export default class OpenFilePlg extends Plugin {
 				.catch((err: Error) => {
 					return {
 						err,
-						stat: null,
+						access: null,
 					};
 				});
 			if (err && !access) {
+				new Notice(
+					[
+						"Bin path in settings may be wrong",
+						err.message.split(":")[1],
+					].join("\n"),
+					5000
+				);
 				return console.log({ err, access });
 			}
 			await execa(file, [derived_path]);


### PR DESCRIPTION
* Allow the file browser pane to open in editor
<img width="438" alt="Screen Shot 2023-06-13 at 3 28 41 PM" src="https://github.com/yekingyan/obsidian-open-in-other-editor/assets/29618692/7a47931f-94c9-4abd-8d30-e5399de1716d">

## TESTING
* Tested on mac and vscode
  * Open one single file selection 🆗 
  * Open on multiple file selection 🆗 
  * Open on folder (a new vscode window will appear with all files in folder. 🆗 
  * Open on active file (original functionality) 🆗 
  
## CONCERNS

This reuses the code for open so it will fail gracefully for anything not mac. 
As such, discussion needs to be had on the UI side. 
My concern is that the contextmenu is too busy for all 3 editors to have their own editors. 
There are three solutions.
* Nested context menu. 
   * Unpopular, requires multiple clicks.
* Toggle the preferred editor

The best option would be to allow the toggle to create the  editors in hand. 
So that each one can appear in the contextmenu. Or none at all.

I have used Notices to replace warning messages so the user has more feedback on code behavior. 

--Raw--
Open folder in vscode.
Overload open.
Add seperator and tap for setting display builder.
Remove console logs.
Open multiple files.
Better notification messages.
Type improvements: settings config , editor consts
Refactor contextmenus feature.